### PR TITLE
RFC: Fix unaligned memory access

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 NAME = ntpperf
 
 CPPFLAGS = -D_GNU_SOURCE
-CFLAGS = -O2 -Wall -g
+CFLAGS ?= -O2 -Wall -g
 LDFLAGS = -lpcap -lm
 
 ifdef NTPPERF_NTS

--- a/sender.h
+++ b/sender.h
@@ -59,4 +59,61 @@ int sender_start(struct sender_config *config);
 bool sender_send_requests(int sender_fd, struct sender_request *requests, int num);
 void sender_stop(int sender_fd);
 
+#define GET_UNALIGNED(ptr) __extension__	\
+({						\
+	struct __attribute__((packed)) {	\
+            __typeof__(*(ptr)) __v;		\
+	} *__p = (__typeof__(__p)) (ptr);	\
+	__p->__v;				\
+})
+
+#define PUT_UNALIGNED(val, ptr)		\
+do {						\
+	struct __attribute__((packed)) {	\
+		__typeof__(*(ptr)) __v;		\
+	} *__p = (__typeof__(__p)) (ptr);	\
+	__p->__v = (val);			\
+} while(0)
+
+
+static inline uint8_t get_u8(const void *ptr)
+{
+	return *((const uint8_t *) ptr);
+}
+
+static inline void put_u8(uint8_t val, void *ptr)
+{
+	*((uint8_t *) ptr) = val;
+}
+
+static inline uint16_t get_u16(const void *ptr)
+{
+	return GET_UNALIGNED((const uint16_t *) ptr);
+}
+
+static inline uint32_t get_u32(const void *ptr)
+{
+	return GET_UNALIGNED((const uint32_t *) ptr);
+}
+
+static inline uint32_t get_u64(const void *ptr)
+{
+	return GET_UNALIGNED((const uint32_t *) ptr);
+}
+
+static inline void put_u16(uint16_t val, void *ptr)
+{
+	PUT_UNALIGNED(val, (uint16_t *) ptr);
+}
+
+static inline void put_u32(uint32_t val, void *ptr)
+{
+	PUT_UNALIGNED(val, (uint32_t *) ptr);
+}
+
+static inline void put_u64(uint64_t val, void *ptr)
+{
+	PUT_UNALIGNED(val, (uint64_t *) ptr);
+}
+
 #endif


### PR DESCRIPTION
This is a mix of a bug report and a RFC, the bug report is that I had some problems with packets being dropped on the receiving side because of wrong checksums, and while investigating that I found some unaligned memory access warnings, which seemed to be the cause of the wrong checksums.

The RFC part is how I tried to fix that, but it is only lightly tested this and I am not sure that this is the better way to solve the issue for the project. I tried to keep the code as similar as I could to the original, so any deviation from the original "spirit" could be detected "at a glance".

I am thinking that adding (and using) the complete "get_unaligned + endianess conversion" calls (for example, https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/asm-generic/unaligned.h#n60) could be a good idea, but opinions are welcome.